### PR TITLE
fix(keybinding): Allow snippet tabstop & multicursor function

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,17 @@
 		}],
         "keybindings": [
 			{
+				"command": "-tabout",
+				"key":"tab",
+				"mac": "tab",
+				"when": "editorTextFocus && !suggestWidgetVisible"
+			},
+			{
 				"command": "tabout",
 				"key":"tab",
 				"mac": "tab",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-			}]
+				"when": "editorTextFocus && !suggestWidgetVisible && !inSnippetMode && !editorHasMultipleSelections"
+            }]
     },
     "scripts": {
         "vscode:prepublish": "node ./node_modules/vscode/bin/compile",


### PR DESCRIPTION
Tabout was consuming the tab function while in snippet mode and while
having multiple cursors enabled on tabout completion characters.

This allows the tab stop function in snippet mode to work as expected
without changing any keybinding settings or disabiling the extention.
Same for the multicursor.

Resolves: #4, #7, #10