### PR TITLE
fix(keybindings): Fix 'command -tabout not found' msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,6 @@
 		}],
         "keybindings": [
 			{
-				"command": "-tabout",
-				"key":"tab",
-				"mac": "tab",
-				"when": "editorTextFocus && !suggestWidgetVisible"
-			},
-			{
 				"command": "tabout",
 				"key":"tab",
 				"mac": "tab",


### PR DESCRIPTION
Previous pull request had a keybinding command -tabout which worked
when it was in vscode 'keybindings.json' file but caused the TabOut
extension to error out because it couldn't find '-tabout' command.

This commit removes that portion of the keybinding. It has been tested
in debug mode in VScode and appears to function as expected.

Resolves: #14