### PR TITLE
Add '%' characterset

### DIFF
--- a/src/charactersToTabOutFrom.ts
+++ b/src/charactersToTabOutFrom.ts
@@ -17,6 +17,7 @@ export function  characterSetsToTabOutFrom() :Array<CharacterSet> {
 	charArray.push(new CharacterSet('.', '.'));
 	charArray.push(new CharacterSet('`', '`'));
 	charArray.push(new CharacterSet(';', ';'));
+	charArray.push(new CharacterSet('%', '%'));
 
 	return charArray
 }


### PR DESCRIPTION
Added `%` as a characterset to tab out from, for Django style code blocks (e.g.: `{% endfor %}`