### PR TITLE
Fix tab key conflict with Copilot inline suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "command": "tabout",
         "key": "tab",
         "mac": "tab",
-        "when": "editorTextFocus && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !editorHasMultipleSelections"
+        "when": "editorTextFocus && !editorHasMultipleSelections && !inSnippetMode && !inlineEditIsVisible && !inlineSuggestionVisible && !suggestWidgetVisible"
       }
     ]
   },


### PR DESCRIPTION
- Add !inlineEditIsVisible condition to tab keybinding
- Prevents tabout from interfering with Copilot suggestion acceptance
- Reorder conditions for better logical flow

Fixes issue where pressing tab would trigger tabout instead of accepting Copilot suggestions