### PR TITLE
Fix snippet mode, Copilot interference, and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "command": "tabout",
         "key": "tab",
         "mac": "tab",
-        "when": "editorTextFocus && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !editorHasMultipleSelections"
+        "when": "editorTextFocus && !suggestWidgetVisible && !inlineSuggestionVisible && !inlineEditIsVisible && !editorHasMultipleSelections"
       }
     ]
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ export function getPreviousChar(currentPosition:number, text:string): string
 
 export function getNextChar(currentPosition:number, text:string): string
 {
-    return text.substring(currentPosition+1, currentPosition);
+    return text.substring(currentPosition+1, currentPosition+2);
 }
 
 export function determineNextSpecialCharPosition(charInfo: CharacterSet, text:string, position: number) : number

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,8 @@ export function getPreviousChar(currentPosition:number, text:string): string
 
 export function getNextChar(currentPosition:number, text:string): string
 {
-    return text.substring(currentPosition+1, currentPosition+2);
+    // Character immediately to the right of the cursor (at current position index)
+    return text.substring(currentPosition, currentPosition+1);
 }
 
 export function determineNextSpecialCharPosition(charInfo: CharacterSet, text:string, position: number) : number

--- a/test/register-vscode-mock.js
+++ b/test/register-vscode-mock.js
@@ -1,0 +1,12 @@
+const Module = require('module');
+const path = require('path');
+
+const originalResolveFilename = Module._resolveFilename;
+const mockPath = path.resolve(__dirname, 'vscode-mock.js');
+
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request === 'vscode') {
+    return mockPath;
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -4,7 +4,7 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { returnHighest, returnLowest, oneNumberIsNegative, getPreviousChar, getNextChar, selectNextCharacter } from '../src/utils';
+import { returnHighest, returnLowest, oneNumberIsNegative, getPreviousChar, getNextChar, selectNextCharacter, determineNextSpecialCharPosition } from '../src/utils';
 
 suite("Utils Tests", () => {
 
@@ -61,5 +61,24 @@ suite("Utils Tests", () => {
 
         assert.equal(mock.window.activeTextEditor.selection.active.character, 6);
         assert.equal(mock.__state.lastCommand, null);
+    });
+
+    test("selectNextCharacter falls back to normal tab when next char is not special", () => {
+        const text = 'abc';
+        const mock = vscode as any;
+        mock.window.activeTextEditor.selection = {
+            active: { line: 0, character: 1 }
+        };
+        mock.__state.lastCommand = null;
+
+        selectNextCharacter(text, 1);
+
+        assert.equal(mock.__state.lastCommand, 'tab');
+        assert.equal(mock.window.activeTextEditor.selection.active.character, 1);
+    });
+
+    test("determineNextSpecialCharPosition finds next close quote", () => {
+        const position = determineNextSpecialCharPosition({ open: '"', close: '"' } as any, '"abc"', 1);
+        assert.equal(position, 4);
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -39,12 +39,12 @@ suite("Utils Tests", () => {
         assert.equal(getPreviousChar(0, "abc"), "");
     });
 
-    test("getNextChar returns character after position", () => {
-        assert.equal(getNextChar(0, "abc"), "b");
-        assert.equal(getNextChar(1, "abc"), "c");
-        assert.equal(getNextChar(4, "hello world"), " ");
-        assert.equal(getNextChar(9, "hello world"), "d");
-        assert.equal(getNextChar(2, "abc"), "");
-        assert.equal(getNextChar(0, "a"), "");
+    test("getNextChar returns character at cursor position (to the right of cursor)", () => {
+        assert.equal(getNextChar(0, "abc"), "a");
+        assert.equal(getNextChar(1, "abc"), "b");
+        assert.equal(getNextChar(4, "hello world"), "o");
+        assert.equal(getNextChar(10, "hello world"), "d");
+        assert.equal(getNextChar(3, "abc"), "");
+        assert.equal(getNextChar(1, "a"), "");
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -44,5 +44,7 @@ suite("Utils Tests", () => {
         assert.equal(getNextChar(1, "abc"), "c");
         assert.equal(getNextChar(4, "hello world"), " ");
         assert.equal(getNextChar(9, "hello world"), "d");
+        assert.equal(getNextChar(2, "abc"), "");
+        assert.equal(getNextChar(0, "a"), "");
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,48 @@
+//
+// Tests for utils.ts functions
+//
+
+import * as assert from 'assert';
+import { returnHighest, returnLowest, oneNumberIsNegative, getPreviousChar, getNextChar } from '../src/utils';
+
+suite("Utils Tests", () => {
+
+    test("returnHighest returns the higher number", () => {
+        assert.equal(returnHighest(5, 3), 5);
+        assert.equal(returnHighest(3, 5), 5);
+        assert.equal(returnHighest(5, 5), 5);
+        assert.equal(returnHighest(-1, 3), 3);
+        assert.equal(returnHighest(0, -5), 0);
+    });
+
+    test("returnLowest returns the lower number", () => {
+        assert.equal(returnLowest(5, 3), 3);
+        assert.equal(returnLowest(3, 5), 3);
+        assert.equal(returnLowest(5, 5), 5);
+        assert.equal(returnLowest(-1, 3), -1);
+        assert.equal(returnLowest(0, -5), -5);
+    });
+
+    test("oneNumberIsNegative detects negative numbers", () => {
+        assert.equal(oneNumberIsNegative(-1, 5), true);
+        assert.equal(oneNumberIsNegative(5, -1), true);
+        assert.equal(oneNumberIsNegative(-1, -1), true);
+        assert.equal(oneNumberIsNegative(0, 5), false);
+        assert.equal(oneNumberIsNegative(5, 0), false);
+        assert.equal(oneNumberIsNegative(0, 0), false);
+    });
+
+    test("getPreviousChar returns character before position", () => {
+        assert.equal(getPreviousChar(1, "abc"), "a");
+        assert.equal(getPreviousChar(2, "abc"), "b");
+        assert.equal(getPreviousChar(5, "hello world"), "o");
+        assert.equal(getPreviousChar(0, "abc"), "");
+    });
+
+    test("getNextChar returns character after position", () => {
+        assert.equal(getNextChar(0, "abc"), "b");
+        assert.equal(getNextChar(1, "abc"), "c");
+        assert.equal(getNextChar(4, "hello world"), " ");
+        assert.equal(getNextChar(9, "hello world"), "d");
+    });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,7 +3,8 @@
 //
 
 import * as assert from 'assert';
-import { returnHighest, returnLowest, oneNumberIsNegative, getPreviousChar, getNextChar } from '../src/utils';
+import * as vscode from 'vscode';
+import { returnHighest, returnLowest, oneNumberIsNegative, getPreviousChar, getNextChar, selectNextCharacter } from '../src/utils';
 
 suite("Utils Tests", () => {
 
@@ -46,5 +47,19 @@ suite("Utils Tests", () => {
         assert.equal(getNextChar(10, "hello world"), "d");
         assert.equal(getNextChar(3, "abc"), "");
         assert.equal(getNextChar(1, "a"), "");
+    });
+
+    test("quote regression: second tab jumps over closing quote", () => {
+        const text = '"dfdf"';
+        const mock = vscode as any;
+        mock.window.activeTextEditor.selection = {
+            active: { line: 0, character: 5 }
+        };
+        mock.__state.lastCommand = null;
+
+        selectNextCharacter(text, 5);
+
+        assert.equal(mock.window.activeTextEditor.selection.active.character, 6);
+        assert.equal(mock.__state.lastCommand, null);
     });
 });

--- a/test/vscode-mock.js
+++ b/test/vscode-mock.js
@@ -12,9 +12,14 @@ class Selection {
   }
 }
 
+const state = {
+  lastCommand: null
+};
+
 module.exports = {
   Position,
   Selection,
+  __state: state,
   window: {
     activeTextEditor: {
       selection: {
@@ -23,11 +28,14 @@ module.exports = {
     }
   },
   commands: {
-    executeCommand: () => Promise.resolve()
+    executeCommand: (command) => {
+      state.lastCommand = command;
+      return Promise.resolve();
+    }
   },
   workspace: {
     getConfiguration: () => ({
-      get: () => []
+      get: (_key, defaultValue) => defaultValue
     })
   }
 };

--- a/test/vscode-mock.js
+++ b/test/vscode-mock.js
@@ -1,0 +1,33 @@
+class Position {
+  constructor(line, character) {
+    this.line = line;
+    this.character = character;
+  }
+}
+
+class Selection {
+  constructor(anchor, active) {
+    this.anchor = anchor;
+    this.active = active;
+  }
+}
+
+module.exports = {
+  Position,
+  Selection,
+  window: {
+    activeTextEditor: {
+      selection: {
+        active: { line: 0, character: 0 }
+      }
+    }
+  },
+  commands: {
+    executeCommand: () => Promise.resolve()
+  },
+  workspace: {
+    getConfiguration: () => ({
+      get: () => []
+    })
+  }
+};


### PR DESCRIPTION
## Summary

This PR addresses issues #53 and #54:

### Issue #53 (Snippet mode)
- Removed  from the keybinding condition
- This allows TabOut to work inside snippet mode, enabling users to tab out of brackets/quotes while within a snippet

### Issue #54 (Copilot interference)
- Added  to the keybinding condition  
- This prevents TabOut from triggering when Copilot Edit Suggestions are visible

### Tests added
- Added  with unit tests for:
  - 
  - 
  - 
  - 
  - 