### PR TITLE
Balanced fix for snippet Tab conflict (Issue #58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,19 @@
           "default": true,
           "description": "Enable Shift+Tab to jump back to the previous TabOut character."
         },
+        "tabout.snippetTabBehavior": {
+          "type": "string",
+          "default": "preferSnippetNavigation",
+          "enum": [
+            "preferSnippetNavigation",
+            "preferTabOut"
+          ],
+          "markdownEnumDescriptions": [
+            "In snippet mode, use **Tab** to move to the next snippet placeholder first. If there is no next placeholder, TabOut behavior applies.",
+            "Always prioritize TabOut behavior, including while in snippet mode."
+          ],
+          "description": "Controls how Tab behaves while snippet mode is active."
+        },
         "tabout.charactersToTabOutFrom": {
           "type": "array",
           "description": "Sets of opening and closing character pairs to be able to tab out from.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
         }));
 
 
-     let tabout = vscode.commands.registerCommand('tabout', () => {
+     let tabout = vscode.commands.registerCommand('tabout', async () => {
         // The code you place here will be executed every time your command is executed
         let editor = window.activeTextEditor;
 
@@ -76,6 +76,31 @@ export function activate(context: vscode.ExtensionContext) {
             {
                 commands.executeCommand("tab");
                 return;
+            }
+        }
+
+        // In snippet mode, allow choosing between snippet placeholder navigation and TabOut behavior.
+        let snippetTabBehavior = vscode.workspace.getConfiguration('tabout').get<string>('snippetTabBehavior', 'preferSnippetNavigation');
+        if(snippetTabBehavior === 'preferSnippetNavigation')
+        {
+            try
+            {
+                let inSnippetMode = await commands.executeCommand<boolean>('getContextKeyValue', 'inSnippetMode');
+                if(inSnippetMode === true)
+                {
+                    let previousPosition = editor.selection.active;
+                    await commands.executeCommand('jumpToNextSnippetPlaceholder');
+
+                    // If snippet navigation moved the cursor, keep native snippet behavior.
+                    if(editor.selection.active.line !== previousPosition.line || editor.selection.active.character !== previousPosition.character)
+                    {
+                        return;
+                    }
+                }
+            }
+            catch
+            {
+                // If context lookup fails, fall back to current TabOut behavior.
             }
         }
 

--- a/test/keybinding.test.ts
+++ b/test/keybinding.test.ts
@@ -47,5 +47,12 @@ suite('Keybinding Guards Tests', () => {
         assert.equal(commands.indexOf('tabout-reverse'), -1, 'tabout-reverse should not be shown as a separate command');
         assert.ok(commands.indexOf('toggle-tabout-reverse-shift-tab') > -1,
             'toggle command for reverse Shift+Tab setting should exist');
+
+        const snippetBehaviorSetting = packageJson.contributes.configuration.properties['tabout.snippetTabBehavior'];
+        assert.ok(snippetBehaviorSetting, 'tabout.snippetTabBehavior setting should exist');
+        assert.equal(snippetBehaviorSetting.default, 'preferSnippetNavigation');
+        assert.ok(Array.isArray(snippetBehaviorSetting.enum), 'snippet behavior should define enum values');
+        assert.ok(snippetBehaviorSetting.enum.indexOf('preferSnippetNavigation') > -1);
+        assert.ok(snippetBehaviorSetting.enum.indexOf('preferTabOut') > -1);
     });
 });


### PR DESCRIPTION
## Summary\n\nThis PR introduces a balanced fix for the snippet-mode Tab conflict reported in #58, while preserving existing TabOut behavior for users who prefer it.\n\n### What changed\n\n- Added new setting: \n  -  (default):\n    - In snippet mode, try native snippet placeholder navigation first ().\n    - If snippet navigation does not move the cursor, TabOut behavior applies as fallback.\n  - :\n    - Always prioritize existing TabOut behavior, including in snippet mode.\n\n- Updated  command implementation to support the behavior above.\n- Added/updated keybinding config tests to cover the new setting and enum values.\n\n## Why this is balanced\n\n- Fixes #58 by default: snippet placeholder flow is respected.\n- Avoids degrading existing workflows: users who rely on TabOut-first behavior in snippets can switch to .\n- Non-snippet behavior is unchanged.\n\n## Validation\n\n- TypeScript compile: 
> TabOut@0.2.4 vscode:prepublish
> tsc -p ./\n- Existing keybinding guard tests updated for new setting metadata.\n\nCloses #58