### PR TITLE
fix: prevent TabOut from overriding snippet navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
         "command": "tabout",
         "key": "tab",
         "mac": "tab",
-        "when": "editorTextFocus && !editorHasSelection && !editorHasMultipleSelections && !suggestWidgetVisible && !inlineSuggestionVisible && !inlineEditIsVisible"
+        "when": "editorTextFocus && !inSnippetMode && !hasSnippetCompletions && !editorHasSelection && !editorHasMultipleSelections && !suggestWidgetVisible && !inlineSuggestionVisible && !inlineEditIsVisible"
       },
       {
         "command": "tabout-reverse",


### PR DESCRIPTION
Fixes #58 

TabOut currently overrides Tab during snippet mode, breaking placeholder navigation.

This PR adds `!inSnippetMode` && `!hasSnippetCompletions` to ensure snippet navigation works correctly.